### PR TITLE
[16.0] Build the image from odoo/odoo

### DIFF
--- a/jeo/16.0.debug/Dockerfile
+++ b/jeo/16.0.debug/Dockerfile
@@ -13,9 +13,4 @@ RUN pip3 install wdb
 # Hacer el parche para que no cheque password
 RUN sed -i  "s/raise AccessDenied()/pass/" /usr/lib/python3/dist-packages/odoo/addons/base/models/res_users.py
 
-# Correr un demonio para atrapar los mails.
-RUN python3 -m smtpd -n -c DebuggingServer localhost:2500 >  /var/log/odoo/maillog.txt &
-
-RUN apt install procps -y
-
 USER odoo

--- a/jeo/16.0.debug/Dockerfile
+++ b/jeo/16.0.debug/Dockerfile
@@ -11,6 +11,6 @@ COPY ./extract_dist-local-packages.sh /
 RUN pip3 install wdb
 
 # Hacer el parche para que no cheque password
-RUN sed -i  "s/raise AccessDenied()/pass/" /usr/lib/python3/dist-packages/odoo/addons/base/models/res_users.py
+#RUN sed -i  "s/raise AccessDenied()/pass/" /usr/lib/python3/dist-packages/odoo/addons/base/models/res_users.py
 
 USER odoo

--- a/jeo/16.0.debug/extract_dist-local-packages.sh
+++ b/jeo/16.0.debug/extract_dist-local-packages.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ################################################################
 # Extrae los odoo packages de la imagen al host para desarrollo
-# revision 2023-11-02
+# revision 2025-07-29
 
-cp -r /usr/local/lib/python3.9/dist-packages/* /mnt/dist-local-packages/
+#cp -r /usr/local/lib/python3.9/dist-packages/* /mnt/dist-local-packages/

--- a/jeo/16.0.debug/make.sh
+++ b/jeo/16.0.debug/make.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-sd build --rm=true -t jobiols/odoo-jeo:16.0.debug ./
+sudo docker build -t jobiols/odoo-jeo:16.0.debug ./
 result=$?
 if [ "$result" -eq 0 ]; then
     sd push jobiols/odoo-jeo:16.0.debug

--- a/jeo/16.0/Dockerfile
+++ b/jeo/16.0/Dockerfile
@@ -1,4 +1,6 @@
-# terminado 1.82GB
+# terminado      1.82GB
+# quitar el .git 1.65GB
+# 1.93GB
 
 ################################################################################
 # Etapa 1: Builder - Compilar Python y preparar dependencias de compilación
@@ -20,11 +22,11 @@ RUN apt-get update && \
         libbz2-dev libreadline-dev libsqlite3-dev libffi-dev \
         libncursesw5-dev xz-utils tk-dev \
         # Para compilar dependencias de Odoo
-        libxml2-dev libxslt1-dev libldap2-dev libsasl2-dev libev-dev libpq-dev \
+        libxml2-dev libxslt1-dev libldap2-dev libsasl2-dev libev-dev libpq-dev swig \
         # Para clonar el repo de Odoo
         git
 
-# --- PASO 1.2: Compilar Python (tu código, sin cambios) ---
+# --- PASO 1.2: Compilar Python
 WORKDIR /tmp
 RUN curl -SL https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz | tar -xz && \
     cd Python-${PYTHON_VERSION} && \
@@ -36,18 +38,30 @@ RUN curl -SL https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON
 # Usamos un Virtual Environment para instalar las dependencias de Odoo.
 # Esto nos permite copiar solo los paquetes instalados a la etapa final,
 # sin necesidad de tener las herramientas de compilación en la imagen final.
+# además estamos eliminando el .git para reducir el tamaño de la imagen final.
 ENV ODOO_VERSION=16.0
-RUN git clone --depth 1 --branch ${ODOO_VERSION} https://github.com/odoo/odoo.git /opt/odoo 
+RUN git clone --depth 1 --branch ${ODOO_VERSION} https://github.com/odoo/odoo.git /opt/odoo && \
+    rm -rf /opt/odoo/.git
 
 RUN python3.10 -m venv /opt/venv && \
     /opt/venv/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
     # Instalar Cython < 3.0 dentro del venv
     /opt/venv/bin/pip install --no-cache-dir "cython<3.0" && \
-    # Instalar los requerimientos de Odoo usando el venv
+    # Instalar los requerimientos de odoo/odoo usando el venv
     /opt/venv/bin/pip install \
         --no-cache-dir \
         --no-build-isolation \
         -r /opt/odoo/requirements.txt
+
+COPY ./requirements /req
+RUN /opt/venv/bin/pip install \
+    # Instalar los requerimientos adicionales de Odoo en el venv librerias de odoo argentina, etc
+    --no-cache-dir \
+    --no-build-isolation \
+    -r /req/odoo-argentina.txt  \
+    -r /req/odoo-argentina-ce.txt  \
+    -r /req/adhoc-aeroo_reports.txt  \
+    -r /req/requirements.txt
 
 ################################################################################
 # Etapa 2: Final/Runtime - Imagen mínima para ejecutar Odoo
@@ -58,7 +72,7 @@ LABEL maintainer="Jorge Obiols <jorge.obiols@gmail.com>"
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8
 # El PATH debe apuntar al venv
-ENV PATH="/opt/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+ENV PATH="/opt/venv/bin:/opt/python/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # --- PASO 2.1: Instalar dependencias de RUNTIME de una sola vez ---
 # - Solo librerías (.so) necesarias, no paquetes -dev.
@@ -87,7 +101,7 @@ RUN apt-get update && \
     # Instalar rtlcss
     npm install -g rtlcss && npm cache clean --force
 
-# --- PASO 2.2: Instalar wkhtmltopdf (tu código, sin cambios) ---
+# --- PASO 2.2: Instalar wkhtmltopdf
 # Este bloque ahora funcionará porque las dependencias ya están instaladas.
 ARG TARGETARCH
 SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
@@ -105,12 +119,12 @@ RUN \
     apt-get install -y --no-install-recommends ./wkhtmltox.deb && \
     rm wkhtmltox.deb
 
-# ... resto del Dockerfile sin cambios ...
 # --- PASO 2.3: Copiar los artefactos de la etapa builder ---
+COPY --from=builder /opt/python /opt/python
 COPY --from=builder /opt/odoo /usr/lib/python3/dist-packages/odoo
 COPY --from=builder /opt/venv /opt/venv
 
-# --- PASO 2.4: Configuración de Odoo
+# --- PASO 2.4: Configuración del usuario Odoo
 RUN groupadd -g 1100 odoo && \
     useradd -u 1100 -g odoo -m -s /bin/bash odoo
 

--- a/jeo/16.0/Dockerfile
+++ b/jeo/16.0/Dockerfile
@@ -1,41 +1,64 @@
-FROM debian:bullseye-slim AS base-image
-LABEL maintainer="Odoo S.A. <info@odoo.com>"
+# Etapa 1: Compilación
+FROM debian:bullseye-slim AS builder
 
-SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
+ARG PYTHON_VERSION=3.10.12
 
-# Generate locale C.UTF-8 for postgres and general locale data
-ENV LANG=C.UTF-8
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    wget \
+    curl \
+    libssl-dev \
+    zlib1g-dev \
+    libbz2-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    libffi-dev \
+    libncursesw5-dev \
+    xz-utils \
+    tk-dev \
+    ca-certificates
+
+# Descargar y compilar Python
+RUN curl -O https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz && \
+    tar -xf Python-${PYTHON_VERSION}.tgz && \
+    cd Python-${PYTHON_VERSION} && \
+    ./configure --enable-optimizations --prefix=/opt/python-${PYTHON_VERSION} && \
+    make -j$(nproc) && \
+    make install
+
+# Etapa 2: Imagen final mínima
+FROM debian:bullseye-slim
+
+ARG PYTHON_VERSION=3.10.12
+
+# Instalar solo las dependencias necesarias para ejecutar Python
+RUN apt-get update && apt-get install -y \
+    libssl1.1 \
+    zlib1g \
+    libbz2-1.0 \
+    libreadline8 \
+    libsqlite3-0 \
+    libffi7 \
+    libncursesw6 \
+    xz-utils \
+    tk \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copiar Python desde el builder
+COPY --from=builder /opt/python-${PYTHON_VERSION} /opt/python-${PYTHON_VERSION}
+
+# Usar ese Python como default
+ENV PATH="/opt/python-${PYTHON_VERSION}/bin:$PATH"
 
 # Retrieve the target architecture to install the correct wkhtmltopdf package
 ARG TARGETARCH
+SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 
-# Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
         dirmngr \
-        fonts-noto-cjk \
-        gnupg \
-        libssl-dev \
-        node-less \
-        npm \
-        python3-magic \
-        python3-num2words \
-        python3-odf \
-        python3-pdfminer \
-        python3-pip \
-        python3-phonenumbers \
-        python3-pyldap \
-        python3-qrcode \
-        python3-renderpm \
-        python3-setuptools \
-        python3-slugify \
-        python3-vobject \
-        python3-watchdog \
-        python3-xlrd \
-        python3-xlwt \
-        xz-utils && \
     if [ -z "${TARGETARCH}" ]; then \
         TARGETARCH="$(dpkg --print-architecture)"; \
     fi; \
@@ -64,93 +87,166 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' > /et
     && rm -f /etc/apt/sources.list.d/pgdg.list \
     && rm -rf /var/lib/apt/lists/*
 
-# Install rtlcss (on Debian buster)
-RUN npm install -g rtlcss
 
-# Install Odoo
-ENV ODOO_VERSION=16.0
-ARG ODOO_RELEASE=20250613
-#ARG ODOO_SHA=1fb02a432e076dd71aca7a7611a07223919356b9
-RUN curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
-#    && echo "${ODOO_SHA} odoo.deb" | sha1sum -c - \
-    && apt-get update \
-    && apt-get -y install --no-install-recommends ./odoo.deb \
-    && rm -rf /var/lib/apt/lists/* odoo.deb
 
-#Cambiar uid y gid en odoo
-RUN groupmod -g 1100 odoo \
-  && usermod -u 1100 -g 1100 odoo
 
-# Copy entrypoint script and Odoo configuration file
-COPY ./entrypoint.sh /
-COPY ./odoo.conf /etc/odoo/
 
-# Set permissions and Mount /var/lib/odoo to allow restoring filestore and /mnt/extra-addons for users addons
-RUN chown odoo /etc/odoo/odoo.conf \
-    && mkdir -p /mnt/extra-addons \
-    && chown -R odoo /mnt/extra-addons
-VOLUME ["/var/lib/odoo", "/mnt/extra-addons"]
 
-# Expose Odoo services
-EXPOSE 8069 8071 8072
 
-# Set the default config file
-ENV ODOO_RC=/etc/odoo/odoo.conf
 
-COPY wait-for-psql.py /usr/local/bin/wait-for-psql.py
+# FROM debian:bullseye-slim AS base-image
+# LABEL maintainer="Odoo S.A. <info@odoo.com>"
 
-# Set default user when running the container
-USER odoo
+# SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 
-ENTRYPOINT ["/entrypoint.sh"]
-CMD ["odoo"]
+# # Generate locale C.UTF-8 for postgres and general locale data
+# ENV LANG=C.UTF-8
 
-###############################################################################
-############################ Fin de base image ################################
-###############################################################################
+# # Retrieve the target architecture to install the correct wkhtmltopdf package
+# ARG TARGETARCH
 
-FROM base-image
-LABEL maintainer="Jorge Obiols <jorge.obiols@gmail.com>"
+# # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
+# RUN apt-get update && \
+#     apt-get install -y --no-install-recommends \
+#         ca-certificates \
+#         curl \
+#         dirmngr \
+#         fonts-noto-cjk \
+#         gnupg \
+#         libssl-dev \
+#         node-less \
+#         npm \
+#         python3-magic \
+#         python3-num2words \
+#         python3-odf \
+#         python3-pdfminer \
+#         python3-pip \
+#         python3-phonenumbers \
+#         python3-pyldap \
+#         python3-qrcode \
+#         python3-renderpm \
+#         python3-setuptools \
+#         python3-slugify \
+#         python3-vobject \
+#         python3-watchdog \
+#         python3-xlrd \
+#         python3-xlwt \
+#         xz-utils && \
+#     if [ -z "${TARGETARCH}" ]; then \
+#         TARGETARCH="$(dpkg --print-architecture)"; \
+#     fi; \
+#     WKHTMLTOPDF_ARCH=${TARGETARCH} && \
+#     case ${TARGETARCH} in \
+#     "amd64") WKHTMLTOPDF_ARCH=amd64 && WKHTMLTOPDF_SHA=9df8dd7b1e99782f1cfa19aca665969bbd9cc159  ;; \
+#     "arm64")  WKHTMLTOPDF_SHA=58c84db46b11ba0e14abb77a32324b1c257f1f22  ;; \
+#     "ppc64le" | "ppc64el") WKHTMLTOPDF_ARCH=ppc64el && WKHTMLTOPDF_SHA=7ed8f6dcedf5345a3dd4eeb58dc89704d862f9cd  ;; \
+#     esac \
+#     && curl -o wkhtmltox.deb -sSL https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.bullseye_${WKHTMLTOPDF_ARCH}.deb \
+#     && echo ${WKHTMLTOPDF_SHA} wkhtmltox.deb | sha1sum -c - \
+#     && apt-get install -y --no-install-recommends ./wkhtmltox.deb \
+#     && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
 
-USER root
+# # install latest postgresql-client
+# RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+#     && GNUPGHOME="$(mktemp -d)" \
+#     && export GNUPGHOME \
+#     && repokey='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8' \
+#     && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "${repokey}" \
+#     && gpg --batch --armor --export "${repokey}" > /etc/apt/trusted.gpg.d/pgdg.gpg.asc \
+#     && gpgconf --kill all \
+#     && rm -rf "$GNUPGHOME" \
+#     && apt-get update  \
+#     && apt-get install --no-install-recommends -y postgresql-client \
+#     && rm -f /etc/apt/sources.list.d/pgdg.list \
+#     && rm -rf /var/lib/apt/lists/*
 
-ENV ETC_DIR=/opt/odoo/etc
-ENV DATA_DIR=/opt/odoo/data
-ENV LOG_DIR=/var/log/odoo
-ENV BKP_DIR=/var/odoo/backups
-ENV ADDONS_DIR=/opt/odoo/custom-addons
-ENV ODOO_RC=${ETC_DIR}/odoo.conf
-RUN \
-       mkdir -p ${ETC_DIR} \
-    && mkdir -p ${DATA_DIR} \
-    && mkdir -p ${LOG_DIR} \
-    && mkdir -p ${BKP_DIR} \
-    && mkdir -p ${ADDONS_DIR} \
-    && chown -R odoo.odoo /opt/odoo \
-    && chown -R odoo.odoo /var/odoo
+# # Install rtlcss (on Debian buster)
+# RUN npm install -g rtlcss
 
-# instalar el ultimo pip
-RUN curl -fsSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
-    && python3 get-pip.py \
-    && rm get-pip.py
+# # Install Odoo
+# ENV ODOO_VERSION=16.0
+# ARG ODOO_RELEASE=20250613
+# #ARG ODOO_SHA=1fb02a432e076dd71aca7a7611a07223919356b9
+# RUN curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
+# #    && echo "${ODOO_SHA} odoo.deb" | sha1sum -c - \
+#     && apt-get update \
+#     && apt-get -y install --no-install-recommends ./odoo.deb \
+#     && rm -rf /var/lib/apt/lists/* odoo.deb
 
-RUN apt-get -qq update && apt-get install -yqq --no-install-recommends \
-    git python3-dev build-essential
+# #Cambiar uid y gid en odoo
+# RUN groupmod -g 1100 odoo \
+#   && usermod -u 1100 -g 1100 odoo
 
-COPY ./requirements /req
-RUN pip3 install -r /req/requirements.txt
-RUN pip3 install -r /req/odoo-argentina.txt
-#RUN pip3 install -r /req/adhoc-aeroo_reports.txt
-RUN rm -r /req
+# # Copy entrypoint script and Odoo configuration file
+# COPY ./entrypoint.sh /
+# COPY ./odoo.conf /etc/odoo/
 
-# crear cache para pyafipws lo necesita para actualizar desde padron y darle
-# permisos para que pueda escribir desde pyafipws porque ahi hay una base
-# sqlite que se usa cuando se refrescan actividades, impuestos y conceptos.
-RUN mkdir /usr/local/lib/python3.9/dist-packages/pyafipws/cache
-RUN chmod -R 777 /usr/local/lib/python3.9/dist-packages/pyafipws
+# # Set permissions and Mount /var/lib/odoo to allow restoring filestore and /mnt/extra-addons for users addons
+# RUN chown odoo /etc/odoo/odoo.conf \
+#     && mkdir -p /mnt/extra-addons \
+#     && chown -R odoo /mnt/extra-addons
+# VOLUME ["/var/lib/odoo", "/mnt/extra-addons"]
 
-# bajar el cifrado del cliente para evitar el error DH_KEY_TOO_SMALL
-# parece que la afip tiene un cifrado debil.
-RUN sed -i  "s/CipherString = DEFAULT@SECLEVEL=2/CipherString = DEFAULT@SECLEVEL=1/" /etc/ssl/openssl.cnf
+# # Expose Odoo services
+# EXPOSE 8069 8071 8072
 
-USER odoo
+# # Set the default config file
+# ENV ODOO_RC=/etc/odoo/odoo.conf
+
+# COPY wait-for-psql.py /usr/local/bin/wait-for-psql.py
+
+# # Set default user when running the container
+# USER odoo
+
+# ENTRYPOINT ["/entrypoint.sh"]
+# CMD ["odoo"]
+
+# ###############################################################################
+# ############################ Fin de base image ################################
+# ###############################################################################
+
+# FROM base-image
+# LABEL maintainer="Jorge Obiols <jorge.obiols@gmail.com>"
+
+# USER root
+
+# ENV ETC_DIR=/opt/odoo/etc
+# ENV DATA_DIR=/opt/odoo/data
+# ENV LOG_DIR=/var/log/odoo
+# ENV BKP_DIR=/var/odoo/backups
+# ENV ADDONS_DIR=/opt/odoo/custom-addons
+# ENV ODOO_RC=${ETC_DIR}/odoo.conf
+# RUN \
+#        mkdir -p ${ETC_DIR} \
+#     && mkdir -p ${DATA_DIR} \
+#     && mkdir -p ${LOG_DIR} \
+#     && mkdir -p ${BKP_DIR} \
+#     && mkdir -p ${ADDONS_DIR} \
+#     && chown -R odoo.odoo /opt/odoo \
+#     && chown -R odoo.odoo /var/odoo
+
+# # instalar el ultimo pip
+# RUN curl -fsSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+#     && python3 get-pip.py \
+#     && rm get-pip.py
+
+# RUN apt-get -qq update && apt-get install -yqq --no-install-recommends \
+#     git python3-dev build-essential
+
+# COPY ./requirements /req
+# RUN pip3 install -r /req/requirements.txt
+# RUN pip3 install -r /req/odoo-argentina.txt
+# #RUN pip3 install -r /req/adhoc-aeroo_reports.txt
+# RUN rm -r /req
+
+# # crear cache para pyafipws lo necesita para actualizar desde padron y darle
+# # permisos para que pueda escribir desde pyafipws porque ahi hay una base
+# # sqlite que se usa cuando se refrescan actividades, impuestos y conceptos.
+# RUN mkdir /usr/local/lib/python3.9/dist-packages/pyafipws/cache
+# RUN chmod -R 777 /usr/local/lib/python3.9/dist-packages/pyafipws
+
+# # bajar el cifrado del cliente para evitar el error DH_KEY_TOO_SMALL
+# # parece que la afip tiene un cifrado debil.
+# RUN sed -i  "s/CipherString = DEFAULT@SECLEVEL=2/CipherString = DEFAULT@SECLEVEL=1/" /etc/ssl/openssl.cnf
+
+# USER odoo

--- a/jeo/16.0/Dockerfile
+++ b/jeo/16.0/Dockerfile
@@ -121,7 +121,7 @@ RUN \
 
 # --- PASO 2.3: Copiar los artefactos de la etapa builder ---
 COPY --from=builder /opt/python /opt/python
-COPY --from=builder /opt/odoo /usr/lib/python3/dist-packages/odoo
+COPY --from=builder /opt/odoo /usr/bin/odoo
 COPY --from=builder /opt/venv /opt/venv
 
 # --- PASO 2.4: Configuración del usuario Odoo

--- a/jeo/16.0/Dockerfile
+++ b/jeo/16.0/Dockerfile
@@ -1,137 +1,126 @@
-# 0.749
-# con fuentes 1.82
+# terminado 1.82GB
 
-#######################################
-# Etapa 1: compilar Python 3.10.12
-#######################################
+################################################################################
+# Etapa 1: Builder - Compilar Python y preparar dependencias de compilación
+################################################################################
 FROM debian:bullseye-slim AS builder
 ARG PYTHON_VERSION=3.10.12
 ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="/opt/python/bin:${PATH}"
 
-# Dependencias de compilación
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential curl ca-certificates \
-    libssl-dev zlib1g-dev libbz2-dev libreadline-dev \
-    libsqlite3-dev libffi-dev libncursesw5-dev xz-utils tk-dev
+# --- PASO 1.1: Instalar TODAS las dependencias de compilación de una vez ---
+# - Dependencias para compilar Python.
+# - Dependencias para compilar los paquetes de Python de Odoo (lxml, psycopg2, etc.).
+# - Cliente de PostgreSQL para tener las cabeceras correctas.
+# - git para clonar Odoo.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        # Para compilar Python
+        build-essential curl ca-certificates libssl-dev zlib1g-dev \
+        libbz2-dev libreadline-dev libsqlite3-dev libffi-dev \
+        libncursesw5-dev xz-utils tk-dev \
+        # Para compilar dependencias de Odoo
+        libxml2-dev libxslt1-dev libldap2-dev libsasl2-dev libev-dev libpq-dev \
+        # Para clonar el repo de Odoo
+        git
 
-# Descargar y compilar
+# --- PASO 1.2: Compilar Python (tu código, sin cambios) ---
 WORKDIR /tmp
-RUN curl -SL https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz \
-    | tar -xz \
- && cd Python-${PYTHON_VERSION} \
- && ./configure --prefix=/opt/python --enable-optimizations --with-ensurepip=install \
- && make -j"$(nproc)" \
- && make altinstall
+RUN curl -SL https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz | tar -xz && \
+    cd Python-${PYTHON_VERSION} && \
+    ./configure --prefix=/opt/python --enable-optimizations --with-ensurepip=install && \
+    make -j"$(nproc)" && \
+    make altinstall
 
-# Podar cachés y tests para achicar tamaño
-RUN find /opt/python -name '__pycache__' -type d -exec rm -rf {} + \
- && rm -rf /opt/python/lib/python*/test
+# --- PASO 1.3: Clonar Odoo y construir un venv con las dependencias ---
+# Usamos un Virtual Environment para instalar las dependencias de Odoo.
+# Esto nos permite copiar solo los paquetes instalados a la etapa final,
+# sin necesidad de tener las herramientas de compilación en la imagen final.
+ENV ODOO_VERSION=16.0
+RUN git clone --depth 1 --branch ${ODOO_VERSION} https://github.com/odoo/odoo.git /opt/odoo 
 
-# Limpiar build‑deps
-RUN apt-get purge -y --auto-remove build-essential curl \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/* /tmp/*
+RUN python3.10 -m venv /opt/venv && \
+    /opt/venv/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
+    # Instalar Cython < 3.0 dentro del venv
+    /opt/venv/bin/pip install --no-cache-dir "cython<3.0" && \
+    # Instalar los requerimientos de Odoo usando el venv
+    /opt/venv/bin/pip install \
+        --no-cache-dir \
+        --no-build-isolation \
+        -r /opt/odoo/requirements.txt
 
-#######################################
-# Etapa 2: runtime mínimo
-#######################################
+################################################################################
+# Etapa 2: Final/Runtime - Imagen mínima para ejecutar Odoo
+################################################################################
 FROM debian:bullseye-slim
 LABEL maintainer="Jorge Obiols <jorge.obiols@gmail.com>"
 
-ARG PYTHON_VERSION=3.10.12
 ENV DEBIAN_FRONTEND=noninteractive
-ENV PATH="/opt/python/bin:${PATH}"
-# Generate locale C.UTF-8 for postgres and general locale data
 ENV LANG=C.UTF-8
+# El PATH debe apuntar al venv
+ENV PATH="/opt/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
-# Solo librerías necesarias en runtime
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libssl1.1 libffi7 libbz2-1.0 libreadline8 \
-    libsqlite3-0 libncursesw6 zlib1g xz-utils tk \
- && rm -rf /var/lib/apt/lists/*
+# --- PASO 2.1: Instalar dependencias de RUNTIME de una sola vez ---
+# - Solo librerías (.so) necesarias, no paquetes -dev.
+# - Cliente de PostgreSQL del repositorio oficial de PG para consistencia.
+# - wkhtmltopdf y otras herramientas.
+RUN apt-get update && \
+    # Herramientas básicas e instalación del repo de PG
+    apt-get install -y --no-install-recommends gnupg ca-certificates curl && \
+    echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' > /etc/apt/sources.list.d/pgdg.list && \
+    curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg && \
+    apt-get update && \
+    # Instalar todo lo necesario para ejecutar
+    apt-get install -y --no-install-recommends \
+        # Dependencias de Python compilado
+        libssl1.1 libffi7 libbz2-1.0 libreadline8 libsqlite3-0 libncursesw6 zlib1g xz-utils tk \
+        # Dependencias de paquetes de Python (lxml, ldap, etc)
+        libxml2 libxslt1.1 libldap-2.4-2 libsasl2-2 libev4 \
+        # Cliente de PostgreSQL y su librería principal
+        postgresql-client libpq5 \
+        # Dependencias requeridas por wkhtmltox
+        fontconfig libjpeg62-turbo xfonts-75dpi xfonts-base \
+        # Otras herramientas
+        npm fonts-noto-cjk git && \
+    # Limpieza de apt
+    rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/pgdg.list && \
+    # Instalar rtlcss
+    npm install -g rtlcss && npm cache clean --force
 
-# Copiar Python construido desde la etapa de compilación
-COPY --from=builder /opt/python /opt/python
-
-# Symlinks útiles
-RUN ln -s /opt/python/bin/python3.10 /usr/local/bin/python3 \
- && ln -s /opt/python/bin/pip3.10     /usr/local/bin/pip
-
+# --- PASO 2.2: Instalar wkhtmltopdf (tu código, sin cambios) ---
+# Este bloque ahora funcionará porque las dependencias ya están instaladas.
 ARG TARGETARCH
 SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
-
-# Instalar wkhtmltopdf según la arquitectura
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        ca-certificates \
-        curl \
-        git && \
-    if [ -z "${TARGETARCH}" ]; then \
-        TARGETARCH="$(dpkg --print-architecture)"; \
-    fi; \
+RUN \
+    if [ -z "${TARGETARCH}" ]; then TARGETARCH="$(dpkg --print-architecture)"; fi; \
     WKHTMLTOPDF_ARCH=${TARGETARCH} && \
     case ${TARGETARCH} in \
-    "amd64") WKHTMLTOPDF_ARCH=amd64 && WKHTMLTOPDF_SHA=9df8dd7b1e99782f1cfa19aca665969bbd9cc159  ;; \
-    "arm64")  WKHTMLTOPDF_SHA=58c84db46b11ba0e14abb77a32324b1c257f1f22  ;; \
-    "ppc64le" | "ppc64el") WKHTMLTOPDF_ARCH=ppc64el && WKHTMLTOPDF_SHA=7ed8f6dcedf5345a3dd4eeb58dc89704d862f9cd  ;; \
-    esac \
-    && curl -o wkhtmltox.deb -sSL https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.bullseye_${WKHTMLTOPDF_ARCH}.deb \
-    && echo ${WKHTMLTOPDF_SHA} wkhtmltox.deb | sha1sum -c - \
-    && apt-get install -y --no-install-recommends ./wkhtmltox.deb \
-    && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
+        "amd64") WKHTMLTOPDF_ARCH=amd64; WKHTMLTOPDF_SHA=9df8dd7b1e99782f1cfa19aca665969bbd9cc159 ;; \
+        "arm64") WKHTMLTOPDF_SHA=58c84db46b11ba0e14abb77a32324b1c257f1f22 ;; \
+        "ppc64le" | "ppc64el") WKHTMLTOPDF_ARCH=ppc64el; WKHTMLTOPDF_SHA=7ed8f6dcedf5345a3dd4eeb58dc89704d862f9cd ;; \
+    esac && \
+    curl -o wkhtmltox.deb -sSL https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.bullseye_${WKHTMLTOPDF_ARCH}.deb && \
+    echo "${WKHTMLTOPDF_SHA} wkhtmltox.deb" | sha1sum -c - && \
+    # Este comando ahora debería tener éxito
+    apt-get install -y --no-install-recommends ./wkhtmltox.deb && \
+    rm wkhtmltox.deb
 
-# Instalar cliente de PostgreSQL
-RUN apt-get update && apt-get install -y --no-install-recommends gnupg ca-certificates \
- && echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
- && export GNUPGHOME="$(mktemp -d)" \
- && gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
- && gpg --batch --armor --export B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 > /etc/apt/trusted.gpg.d/pgdg.gpg.asc \
- && gpgconf --kill all \
- && rm -rf "$GNUPGHOME" \
- && apt-get update \
- && apt-get install -y --no-install-recommends postgresql-client \
- && rm -f /etc/apt/sources.list.d/pgdg.list \
- && rm -rf /var/lib/apt/lists/*
+# ... resto del Dockerfile sin cambios ...
+# --- PASO 2.3: Copiar los artefactos de la etapa builder ---
+COPY --from=builder /opt/odoo /usr/lib/python3/dist-packages/odoo
+COPY --from=builder /opt/venv /opt/venv
 
-# Install rtlcss (soporte RTL, escribir lenguajes de derecha a izq como árabe o hebreo) hacer esto en la primera etapa
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        npm && \
-    # Instalar rtlcss
-    npm install -g rtlcss
-
-# instalar fuentes de odoo community para chino y japonés
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        fonts-noto-cjk
-
-# Instalar odoo community
-ENV ODOO_VERSION=16.0
-ARG ODOO_RELEASE=${ODOO_RELEASE}
-
-RUN git clone --depth 1 --branch ${ODOO_VERSION} \
-    https://github.com/odoo/odoo.git /usr/lib/python3/dist-packages/odoo
-
-# Cambiar uid y gid en odoo para que coincidan con el usuario del host
+# --- PASO 2.4: Configuración de Odoo
 RUN groupadd -g 1100 odoo && \
     useradd -u 1100 -g odoo -m -s /bin/bash odoo
 
-# Copy entrypoint script and Odoo configuration file, and wait-for-psql script
 COPY ./entrypoint.sh /
 COPY ./odoo.conf /etc/odoo/
 COPY ./wait-for-psql.py /usr/local/bin/wait-for-psql.py
 
-# Set permissions and Mount /var/lib/odoo to allow restoring filestore and /mnt/extra-addons for users addons
-RUN chown odoo /etc/odoo/odoo.conf \
-    && mkdir -p /mnt/extra-addons \
-    && chown -R odoo /mnt/extra-addons
-VOLUME ["/var/lib/odoo", "/mnt/extra-addons"]
-
-# Expose Odoo services
-EXPOSE 8069 8071 8072
-
-# Set the default config file
-ENV ODOO_RC=/etc/odoo/odoo.conf
+RUN chown odoo /etc/odoo/odoo.conf && \
+    mkdir -p /mnt/extra-addons && \
+    chown -R odoo /mnt/extra-addons
 
 ENV ETC_DIR=/opt/odoo/etc
 ENV DATA_DIR=/opt/odoo/data
@@ -139,180 +128,14 @@ ENV LOG_DIR=/var/log/odoo
 ENV BKP_DIR=/var/odoo/backups
 ENV ADDONS_DIR=/opt/odoo/custom-addons
 ENV ODOO_RC=${ETC_DIR}/odoo.conf
-RUN \
-       mkdir -p ${ETC_DIR} \
-    && mkdir -p ${DATA_DIR} \
-    && mkdir -p ${LOG_DIR} \
-    && mkdir -p ${BKP_DIR} \
-    && mkdir -p ${ADDONS_DIR} \
-    && chown -R odoo.odoo /opt/odoo \
-    && chown -R odoo.odoo /var/odoo
+RUN mkdir -p ${ETC_DIR} ${DATA_DIR} ${LOG_DIR} ${BKP_DIR} ${ADDONS_DIR} && \
+    chown -R odoo:odoo /opt/odoo /var/odoo
 
-# Instala las dependencias del sistema operativo, incluyendo las de desarrollo de PostgreSQL.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    python3-dev \
-    libxml2-dev \
-    libxslt1-dev \
-    libldap2-dev \
-    libsasl2-dev \
-    libffi-dev \
-    libssl-dev \
-    libev-dev \
-    pkg-config \
-    curl \
-    libpq-dev \
-    && rm -rf /var/lib/apt/lists/*
+VOLUME ["/var/lib/odoo", "/mnt/extra-addons"]
+EXPOSE 8069 8071 8072
+ENV ODOO_RC=/etc/odoo/odoo.conf
 
-# Instala las dependencias de Python.
-# Este bloque ya está correcto y no necesita cambios.
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    pip install --no-cache-dir "cython<3.0" && \
-    pip install \
-        --no-cache-dir \
-        --no-build-isolation \
-        -r /usr/lib/python3/dist-packages/odoo/requirements.txt
-
-
-# Set default user when running the container
-# USER odoo
-
-# ENTRYPOINT ["/entrypoint.sh"]
-# CMD ["odoo"]
-
-
-
-
-
-# # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
-# RUN apt-get update && \
-#     apt-get install -y --no-install-recommends \
-#         ca-certificates \
-#         curl \
-#         dirmngr \
-#         fonts-noto-cjk \
-#         gnupg \
-#         libssl-dev \
-#         node-less \
-#         npm \
-#         python3-magic \
-#         python3-num2words \
-#         python3-odf \
-#         python3-pdfminer \
-#         python3-pip \
-#         python3-phonenumbers \
-#         python3-pyldap \
-#         python3-qrcode \
-#         python3-renderpm \
-#         python3-setuptools \
-#         python3-slugify \
-#         python3-vobject \
-#         python3-watchdog \
-#         python3-xlrd \
-#         python3-xlwt \
-#         xz-utils && \
-#     if [ -z "${TARGETARCH}" ]; then \
-#         TARGETARCH="$(dpkg --print-architecture)"; \
-#     fi; \
-#     WKHTMLTOPDF_ARCH=${TARGETARCH} && \
-#     case ${TARGETARCH} in \
-#     "amd64") WKHTMLTOPDF_ARCH=amd64 && WKHTMLTOPDF_SHA=9df8dd7b1e99782f1cfa19aca665969bbd9cc159  ;; \
-#     "arm64")  WKHTMLTOPDF_SHA=58c84db46b11ba0e14abb77a32324b1c257f1f22  ;; \
-#     "ppc64le" | "ppc64el") WKHTMLTOPDF_ARCH=ppc64el && WKHTMLTOPDF_SHA=7ed8f6dcedf5345a3dd4eeb58dc89704d862f9cd  ;; \
-#     esac \
-#     && curl -o wkhtmltox.deb -sSL https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.bullseye_${WKHTMLTOPDF_ARCH}.deb \
-#     && echo ${WKHTMLTOPDF_SHA} wkhtmltox.deb | sha1sum -c - \
-#     && apt-get install -y --no-install-recommends ./wkhtmltox.deb \
-#     && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
-
-
-# # Install rtlcss (on Debian buster)
-# RUN npm install -g rtlcss
-
-# # Install Odoo
-# ENV ODOO_VERSION=16.0
-# ARG ODOO_RELEASE=20250613
-# #ARG ODOO_SHA=1fb02a432e076dd71aca7a7611a07223919356b9
-# RUN curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
-# #    && echo "${ODOO_SHA} odoo.deb" | sha1sum -c - \
-#     && apt-get update \
-#     && apt-get -y install --no-install-recommends ./odoo.deb \
-#     && rm -rf /var/lib/apt/lists/* odoo.deb
-
-# #Cambiar uid y gid en odoo
-# RUN groupmod -g 1100 odoo \
-#   && usermod -u 1100 -g 1100 odoo
-
-# # Copy entrypoint script and Odoo configuration file
-# COPY ./entrypoint.sh /
-# COPY ./odoo.conf /etc/odoo/
-
-# # Set permissions and Mount /var/lib/odoo to allow restoring filestore and /mnt/extra-addons for users addons
-# RUN chown odoo /etc/odoo/odoo.conf \
-#     && mkdir -p /mnt/extra-addons \
-#     && chown -R odoo /mnt/extra-addons
-# VOLUME ["/var/lib/odoo", "/mnt/extra-addons"]
-
-# # Expose Odoo services
-# EXPOSE 8069 8071 8072
-
-# # Set the default config file
-# ENV ODOO_RC=/etc/odoo/odoo.conf
-
-# COPY wait-for-psql.py /usr/local/bin/wait-for-psql.py
-
-# # Set default user when running the container
-# USER odoo
-
-# ENTRYPOINT ["/entrypoint.sh"]
-# CMD ["odoo"]
-
-# ###############################################################################
-# ############################ Fin de base image ################################
-# ###############################################################################
-
-# FROM base-image
-# LABEL maintainer="Jorge Obiols <jorge.obiols@gmail.com>"
-
-# USER root
-
-# ENV ETC_DIR=/opt/odoo/etc
-# ENV DATA_DIR=/opt/odoo/data
-# ENV LOG_DIR=/var/log/odoo
-# ENV BKP_DIR=/var/odoo/backups
-# ENV ADDONS_DIR=/opt/odoo/custom-addons
-# ENV ODOO_RC=${ETC_DIR}/odoo.conf
-# RUN \
-#        mkdir -p ${ETC_DIR} \
-#     && mkdir -p ${DATA_DIR} \
-#     && mkdir -p ${LOG_DIR} \
-#     && mkdir -p ${BKP_DIR} \
-#     && mkdir -p ${ADDONS_DIR} \
-#     && chown -R odoo.odoo /opt/odoo \
-#     && chown -R odoo.odoo /var/odoo
-
-# # instalar el ultimo pip
-# RUN curl -fsSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
-#     && python3 get-pip.py \
-#     && rm get-pip.py
-
-# RUN apt-get -qq update && apt-get install -yqq --no-install-recommends \
-#     git python3-dev build-essential
-
-# COPY ./requirements /req
-# RUN pip3 install -r /req/requirements.txt
-# RUN pip3 install -r /req/odoo-argentina.txt
-# #RUN pip3 install -r /req/adhoc-aeroo_reports.txt
-# RUN rm -r /req
-
-# # crear cache para pyafipws lo necesita para actualizar desde padron y darle
-# # permisos para que pueda escribir desde pyafipws porque ahi hay una base
-# # sqlite que se usa cuando se refrescan actividades, impuestos y conceptos.
-# RUN mkdir /usr/local/lib/python3.9/dist-packages/pyafipws/cache
-# RUN chmod -R 777 /usr/local/lib/python3.9/dist-packages/pyafipws
-
-# # bajar el cifrado del cliente para evitar el error DH_KEY_TOO_SMALL
-# # parece que la afip tiene un cifrado debil.
-# RUN sed -i  "s/CipherString = DEFAULT@SECLEVEL=2/CipherString = DEFAULT@SECLEVEL=1/" /etc/ssl/openssl.cnf
-
-# USER odoo
+# Set default user and entrypoint
+USER odoo
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["odoo"]

--- a/jeo/16.0/Dockerfile
+++ b/jeo/16.0/Dockerfile
@@ -1,64 +1,71 @@
-# Etapa 1: Compilación
+# 0.749
+# con fuentes 1.82
+
+#######################################
+# Etapa 1: compilar Python 3.10.12
+#######################################
 FROM debian:bullseye-slim AS builder
-
 ARG PYTHON_VERSION=3.10.12
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    wget \
-    curl \
-    libssl-dev \
-    zlib1g-dev \
-    libbz2-dev \
-    libreadline-dev \
-    libsqlite3-dev \
-    libffi-dev \
-    libncursesw5-dev \
-    xz-utils \
-    tk-dev \
-    ca-certificates
+# Dependencias de compilación
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential curl ca-certificates \
+    libssl-dev zlib1g-dev libbz2-dev libreadline-dev \
+    libsqlite3-dev libffi-dev libncursesw5-dev xz-utils tk-dev
 
-# Descargar y compilar Python
-RUN curl -O https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz && \
-    tar -xf Python-${PYTHON_VERSION}.tgz && \
-    cd Python-${PYTHON_VERSION} && \
-    ./configure --enable-optimizations --prefix=/opt/python-${PYTHON_VERSION} && \
-    make -j$(nproc) && \
-    make install
+# Descargar y compilar
+WORKDIR /tmp
+RUN curl -SL https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz \
+    | tar -xz \
+ && cd Python-${PYTHON_VERSION} \
+ && ./configure --prefix=/opt/python --enable-optimizations --with-ensurepip=install \
+ && make -j"$(nproc)" \
+ && make altinstall
 
-# Etapa 2: Imagen final mínima
+# Podar cachés y tests para achicar tamaño
+RUN find /opt/python -name '__pycache__' -type d -exec rm -rf {} + \
+ && rm -rf /opt/python/lib/python*/test
+
+# Limpiar build‑deps
+RUN apt-get purge -y --auto-remove build-essential curl \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/*
+
+#######################################
+# Etapa 2: runtime mínimo
+#######################################
 FROM debian:bullseye-slim
+LABEL maintainer="Jorge Obiols <jorge.obiols@gmail.com>"
 
 ARG PYTHON_VERSION=3.10.12
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="/opt/python/bin:${PATH}"
+# Generate locale C.UTF-8 for postgres and general locale data
+ENV LANG=C.UTF-8
 
-# Instalar solo las dependencias necesarias para ejecutar Python
-RUN apt-get update && apt-get install -y \
-    libssl1.1 \
-    zlib1g \
-    libbz2-1.0 \
-    libreadline8 \
-    libsqlite3-0 \
-    libffi7 \
-    libncursesw6 \
-    xz-utils \
-    tk \
-    && rm -rf /var/lib/apt/lists/*
+# Solo librerías necesarias en runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libssl1.1 libffi7 libbz2-1.0 libreadline8 \
+    libsqlite3-0 libncursesw6 zlib1g xz-utils tk \
+ && rm -rf /var/lib/apt/lists/*
 
-# Copiar Python desde el builder
-COPY --from=builder /opt/python-${PYTHON_VERSION} /opt/python-${PYTHON_VERSION}
+# Copiar Python construido desde la etapa de compilación
+COPY --from=builder /opt/python /opt/python
 
-# Usar ese Python como default
-ENV PATH="/opt/python-${PYTHON_VERSION}/bin:$PATH"
+# Symlinks útiles
+RUN ln -s /opt/python/bin/python3.10 /usr/local/bin/python3 \
+ && ln -s /opt/python/bin/pip3.10     /usr/local/bin/pip
 
-# Retrieve the target architecture to install the correct wkhtmltopdf package
 ARG TARGETARCH
 SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 
+# Instalar wkhtmltopdf según la arquitectura
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
-        git \
+        git && \
     if [ -z "${TARGETARCH}" ]; then \
         TARGETARCH="$(dpkg --print-architecture)"; \
     fi; \
@@ -73,37 +80,109 @@ RUN apt-get update && \
     && apt-get install -y --no-install-recommends ./wkhtmltox.deb \
     && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
 
-# install latest postgresql-client
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
-    && GNUPGHOME="$(mktemp -d)" \
-    && export GNUPGHOME \
-    && repokey='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8' \
-    && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "${repokey}" \
-    && gpg --batch --armor --export "${repokey}" > /etc/apt/trusted.gpg.d/pgdg.gpg.asc \
-    && gpgconf --kill all \
-    && rm -rf "$GNUPGHOME" \
-    && apt-get update  \
-    && apt-get install --no-install-recommends -y postgresql-client \
-    && rm -f /etc/apt/sources.list.d/pgdg.list \
+# Instalar cliente de PostgreSQL
+RUN apt-get update && apt-get install -y --no-install-recommends gnupg ca-certificates \
+ && echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+ && export GNUPGHOME="$(mktemp -d)" \
+ && gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
+ && gpg --batch --armor --export B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 > /etc/apt/trusted.gpg.d/pgdg.gpg.asc \
+ && gpgconf --kill all \
+ && rm -rf "$GNUPGHOME" \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends postgresql-client \
+ && rm -f /etc/apt/sources.list.d/pgdg.list \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install rtlcss (soporte RTL, escribir lenguajes de derecha a izq como árabe o hebreo) hacer esto en la primera etapa
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        npm && \
+    # Instalar rtlcss
+    npm install -g rtlcss
+
+# instalar fuentes de odoo community para chino y japonés
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        fonts-noto-cjk
+
+# Instalar odoo community
+ENV ODOO_VERSION=16.0
+ARG ODOO_RELEASE=${ODOO_RELEASE}
+
+RUN git clone --depth 1 --branch ${ODOO_VERSION} \
+    https://github.com/odoo/odoo.git /usr/lib/python3/dist-packages/odoo
+
+# Cambiar uid y gid en odoo para que coincidan con el usuario del host
+RUN groupadd -g 1100 odoo && \
+    useradd -u 1100 -g odoo -m -s /bin/bash odoo
+
+# Copy entrypoint script and Odoo configuration file, and wait-for-psql script
+COPY ./entrypoint.sh /
+COPY ./odoo.conf /etc/odoo/
+COPY ./wait-for-psql.py /usr/local/bin/wait-for-psql.py
+
+# Set permissions and Mount /var/lib/odoo to allow restoring filestore and /mnt/extra-addons for users addons
+RUN chown odoo /etc/odoo/odoo.conf \
+    && mkdir -p /mnt/extra-addons \
+    && chown -R odoo /mnt/extra-addons
+VOLUME ["/var/lib/odoo", "/mnt/extra-addons"]
+
+# Expose Odoo services
+EXPOSE 8069 8071 8072
+
+# Set the default config file
+ENV ODOO_RC=/etc/odoo/odoo.conf
+
+ENV ETC_DIR=/opt/odoo/etc
+ENV DATA_DIR=/opt/odoo/data
+ENV LOG_DIR=/var/log/odoo
+ENV BKP_DIR=/var/odoo/backups
+ENV ADDONS_DIR=/opt/odoo/custom-addons
+ENV ODOO_RC=${ETC_DIR}/odoo.conf
+RUN \
+       mkdir -p ${ETC_DIR} \
+    && mkdir -p ${DATA_DIR} \
+    && mkdir -p ${LOG_DIR} \
+    && mkdir -p ${BKP_DIR} \
+    && mkdir -p ${ADDONS_DIR} \
+    && chown -R odoo.odoo /opt/odoo \
+    && chown -R odoo.odoo /var/odoo
+
+# Instala las dependencias del sistema operativo, incluyendo las de desarrollo de PostgreSQL.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    python3-dev \
+    libxml2-dev \
+    libxslt1-dev \
+    libldap2-dev \
+    libsasl2-dev \
+    libffi-dev \
+    libssl-dev \
+    libev-dev \
+    pkg-config \
+    curl \
+    libpq-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# Instala las dependencias de Python.
+# Este bloque ya está correcto y no necesita cambios.
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
+    pip install --no-cache-dir "cython<3.0" && \
+    pip install \
+        --no-cache-dir \
+        --no-build-isolation \
+        -r /usr/lib/python3/dist-packages/odoo/requirements.txt
+
+
+# Set default user when running the container
+# USER odoo
+
+# ENTRYPOINT ["/entrypoint.sh"]
+# CMD ["odoo"]
 
 
 
 
-
-
-
-# FROM debian:bullseye-slim AS base-image
-# LABEL maintainer="Odoo S.A. <info@odoo.com>"
-
-# SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
-
-# # Generate locale C.UTF-8 for postgres and general locale data
-# ENV LANG=C.UTF-8
-
-# # Retrieve the target architecture to install the correct wkhtmltopdf package
-# ARG TARGETARCH
 
 # # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
 # RUN apt-get update && \
@@ -146,19 +225,6 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' > /et
 #     && apt-get install -y --no-install-recommends ./wkhtmltox.deb \
 #     && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
 
-# # install latest postgresql-client
-# RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
-#     && GNUPGHOME="$(mktemp -d)" \
-#     && export GNUPGHOME \
-#     && repokey='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8' \
-#     && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "${repokey}" \
-#     && gpg --batch --armor --export "${repokey}" > /etc/apt/trusted.gpg.d/pgdg.gpg.asc \
-#     && gpgconf --kill all \
-#     && rm -rf "$GNUPGHOME" \
-#     && apt-get update  \
-#     && apt-get install --no-install-recommends -y postgresql-client \
-#     && rm -f /etc/apt/sources.list.d/pgdg.list \
-#     && rm -rf /var/lib/apt/lists/*
 
 # # Install rtlcss (on Debian buster)
 # RUN npm install -g rtlcss

--- a/jeo/16.0/Dockerfile
+++ b/jeo/16.0/Dockerfile
@@ -58,7 +58,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
-        dirmngr \
+        git \
     if [ -z "${TARGETARCH}" ]; then \
         TARGETARCH="$(dpkg --print-architecture)"; \
     fi; \

--- a/jeo/16.0/make.sh
+++ b/jeo/16.0/make.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-sd build --rm=true -t jobiols/odoo-jeo:16.0 ./
+sd build --rm=true -t jobiols/odoo-jeo:16.01 ./
 result=$?
 if [ "$result" -eq 0 ]; then
-    sd push jobiols/odoo-jeo:16.0
+    sd push jobiols/odoo-jeo:16.01
 else
     echo "Falló la creación de la imagen"
 fi

--- a/jeo/16.0/make.sh
+++ b/jeo/16.0/make.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
-#sd build --rm=true --no-cache -t jobiols/odoo-jeo:16.01 ./
-sudo docker build --build-arg ODOO_RELEASE=$(date +%Y%m%d) --tag jobiols/odoo-jeo:16.01 ./
+sudo docker build --build-arg ODOO_RELEASE=$(date +%Y%m%d) --tag jobiols/odoo-jeo:16.0 ./
 result=$?
 if [ "$result" -eq 0 ]; then
-    sd push jobiols/odoo-jeo:16.01
+    sd push jobiols/odoo-jeo:16.0
 else
     echo "Falló la creación de la imagen"
 fi

--- a/jeo/16.0/make.sh
+++ b/jeo/16.0/make.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-sd build --rm=true -t jobiols/odoo-jeo:16.01 ./
+#sd build --rm=true --no-cache -t jobiols/odoo-jeo:16.01 ./
+sudo docker build --build-arg ODOO_RELEASE=$(date +%Y%m%d) --tag jobiols/odoo-jeo:16.01 ./
 result=$?
 if [ "$result" -eq 0 ]; then
     sd push jobiols/odoo-jeo:16.01

--- a/jeo/16.0/requirements/adhoc-aeroo_reports.txt
+++ b/jeo/16.0/requirements/adhoc-aeroo_reports.txt
@@ -1,5 +1,5 @@
 # use this genshi version to fix error when, for eg, you send arguments like "date=True" check this https://genshi.edgewall.org/ticket/600
-git+https://github.com/edgewall/genshi@stable/0.7.x
+genshi==0.7.7
 # git+https://github.com/aeroo/aeroolib.git
 # waiting for PR https://github.com/aeroo/aeroolib/pull/12
 git+https://github.com/adhoc-dev/aeroolib@master-fix-ods

--- a/jeo/16.0/requirements/odoo-argentina-ce.txt
+++ b/jeo/16.0/requirements/odoo-argentina-ce.txt
@@ -1,0 +1,11 @@
+pyOpenSSL
+M2Crypto
+httplib2>=0.7
+# pysimplesoap~=1.8.22 # lo quito porque en odoo-argentina estan ponniendo una version especifica
+# fpdf>=1.7.2
+# dbf>=0.88.019
+# Pillow>=2.0.0
+# git+https://github.com/OCA/openupgradelib/@master
+# git+https://github.com/reingart/pyafipws@py3k
+# git+https://github.com/ingadhoc/pyafipws@py3k
+#git+https://github.com/filoquin/pyafipws.git@py3k lo quito porque en odoo-argentina estan ponniendo una version especifica

--- a/jeo/16.0/requirements/requirements.txt
+++ b/jeo/16.0/requirements/requirements.txt
@@ -1,18 +1,18 @@
-num2words==0.5.10
-pandas==2.2.2
-paramiko==3.1.0
-astor
+# num2words==0.5.10
+# pandas==2.2.2
+# paramiko==3.1.0
+# astor
 
-# LOPEZ hr_attendance_zktecho
-pyzk
-# LOPEZ izi_data
-sqlparse
+# # LOPEZ hr_attendance_zktecho
+# pyzk
+# # LOPEZ izi_data
+# sqlparse
 
-# upgrade utils
-git+https://github.com/odoo/upgrade-util@master
-markdown
+# # upgrade utils
+# git+https://github.com/odoo/upgrade-util@master
+# markdown
 
-meli @ git+https://github.com/mercadolibre/python-sdk.git@09406bd544b974b379fea4818bd1040c7f147a40
+# meli @ git+https://github.com/mercadolibre/python-sdk.git@09406bd544b974b379fea4818bd1040c7f147a40
 
-unrar
-openpyxl
+# unrar
+# openpyxl


### PR DESCRIPTION
Se dejan de usar las imagenes oficales de odoo porque traen muchos problemas.
- A veces el nightly build viene con errores
- En las imagen 16 usa python 9 cuando debería usar python 3.10.12

Se crea la imagen desde cero trayendo los fuentes de odoo/odoo en lugar del nightly build